### PR TITLE
Fire event when finished processing.

### DIFF
--- a/custom_components/fallback_conversation/__init__.py
+++ b/custom_components/fallback_conversation/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     DEBUG_LEVEL_LOW_DEBUG,
     DEBUG_LEVEL_VERBOSE_DEBUG,
     DOMAIN,
+    EVENT_CONVERSATION_FINISHED,
 )
 
 
@@ -138,7 +139,15 @@ class FallbackConversationAgent(conversation.AbstractConversationAgent):
                 result.response.speech['plain']['speech'] = f"{previous_result.response.speech['plain'].get('agent_name', 'UNKNOWN')} failed with response: {pr} Then {agent_name} responded with {r}"
             else:
                 result.response.speech['plain']['speech'] = f"{agent_name} responded with: {r}"
-
+        
+        self.hass.bus.async_fire(
+            EVENT_CONVERSATION_FINISHED,
+            {
+                "result": result,
+                "user_input": user_input,
+            },
+        )
+        
         return result
 
     def _convert_agent_info_to_dict(self, agents: list[conversation.AgentInfo]) -> dict[str, str]:

--- a/custom_components/fallback_conversation/config_flow.py
+++ b/custom_components/fallback_conversation/config_flow.py
@@ -11,7 +11,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, async_get_hass, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.components.conversation import _get_agent_manager
 from homeassistant.helpers.selector import (
     ConversationAgentSelector, 
     ConversationAgentSelectorConfig,

--- a/custom_components/fallback_conversation/const.py
+++ b/custom_components/fallback_conversation/const.py
@@ -10,5 +10,7 @@ DEBUG_LEVEL_NO_DEBUG = "none"
 DEBUG_LEVEL_LOW_DEBUG = "low"
 DEBUG_LEVEL_VERBOSE_DEBUG = "verbose"
 
+EVENT_CONVERSATION_FINISHED = "fallback_conversation.conversation.finished"
+
 DEFAULT_NAME = "Fallback Conversation Agent"
 DEFAULT_DEBUG_LEVEL = DEBUG_LEVEL_NO_DEBUG


### PR DESCRIPTION
Fires an event in Home Assistant once the conversation agent has finished processing.
This event can be used as a trigger for automations and contains the user_input and result of the conversation agent process. 

I use this event as a trigger and data point in Node-RED to display the user input and response as text on a display as well as call a text to speech service on a different speaker to the satellite that triggered the conversation.