### PR TITLE
Home Assistant 2024.5.0 compatibility

### DIFF
--- a/custom_components/fallback_conversation/config_flow.py
+++ b/custom_components/fallback_conversation/config_flow.py
@@ -11,7 +11,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, async_get_hass, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.components.conversation import _get_agent_manager
 from homeassistant.helpers.selector import (
     ConversationAgentSelector, 
     ConversationAgentSelectorConfig,


### PR DESCRIPTION
Seems that in 2024.5.0:

1. `_get_agent_manager` from conversation module is now public.
2. `default_agent` property from AgentManager is gone. `conversation.default_agent.async_get_default_agent()` looks to be a good alternative for that.
3. The list returned by AgentManager's `async_get_agent_info` [no longer includes the default agent](https://github.com/home-assistant/core/commit/d2e4f5f36e8e46cd0a8516ef92103de7ee2c2a59#diff-3d68c94a7b0865fcec20449cd395166e6fbff4c9a162a22f3ebd50a7ddb7eadfL122).

I updated the code so it gets the default agent from `conversation.default_agent` and appends the default agent (with both the old `homeassistant` and newer `conversation.home_assistant` values) in `agent_names`.