### PR TITLE
Fix for Home Assistant 2024.6.0

### DIFF
--- a/custom_components/fallback_conversation/__init__.py
+++ b/custom_components/fallback_conversation/__init__.py
@@ -146,12 +146,16 @@ class FallbackConversationAgent(conversation.AbstractConversationAgent):
 
         return result
 
-    def _convert_agent_info_to_dict(self, agents: list[conversation.AgentInfo]) -> dict[str, str]:
+    def _convert_agent_info_to_dict(self, agents_info: list[conversation.AgentInfo]) -> dict[str, str]:
         """Takes a list of AgentInfo and makes it a dict of ID -> Name."""
+
+        agent_manager = conversation.get_agent_manager(self.hass)
+
         r = {}
-        for agent in agents:
-            r[agent.id] = agent.name
-
+        for agent_info in agents_info:
+            agent = agent_manager.async_get_agent(agent_info.id)
+            agent_id = None
+            if hasattr(agent, "registry_entry"):
+                agent_id = agent.entity_id
+            r[agent_id] = agent_info.name
         return r
-
-

--- a/custom_components/fallback_conversation/__init__.py
+++ b/custom_components/fallback_conversation/__init__.py
@@ -156,6 +156,6 @@ class FallbackConversationAgent(conversation.AbstractConversationAgent):
             agent = agent_manager.async_get_agent(agent_info.id)
             agent_id = None
             if hasattr(agent, "registry_entry"):
-                agent_id = agent.entity_id
+                agent_id = agent.registry_entry.entity_id
             r[agent_id] = agent_info.name
         return r


### PR DESCRIPTION
Seems that `agent_manager.async_get_agent_info()` now returns `ConfigEntry` `entry_id`s instead of `entity_id`s, while `ConversationAgentSelector` works with `entity_id`s. This means that when we look for an agent name in `agent_names`, we will lookup using an `entity_id` in a dictionary with `entry_id` as keys, so it will fail. To make this worse, we don't have `entry_id`s for the default agents (or I couldn't find one), so we end up with mixed key types in the `agent_names` dictionary. This causes the issue described in #14.

This PR modifies `_convert_agent_info_to_dict` function to check if an agent has a `registry_entry` property. If it does, we get the `entity_id` from there and use that as a key. I'm not 100% confident that this is the proper fix for this issue, so I'm open to suggestions.